### PR TITLE
feat: Implement control arbitration with twist_mux

### DIFF
--- a/indoor_drone_nav_v2/config/control/twist_mux.yaml
+++ b/indoor_drone_nav_v2/config/control/twist_mux.yaml
@@ -1,0 +1,34 @@
+# Configuration for the twist_mux
+twist_mux:
+  ros__parameters:
+    # The output topic for the arbitrated velocity commands
+    cmd_vel_out: "/cmd_vel_out"
+
+    # Define the input topics
+    topics:
+      # Joystick input - highest priority
+      joy:
+        topic: "/cmd_vel/joy"
+        timeout: 0.5
+        priority: 100
+
+      # Navigation stack input
+      nav:
+        topic: "/cmd_vel/nav"
+        timeout: 0.5
+        priority: 10
+
+      # Visual servoing input
+      servo:
+        topic: "/cmd_vel/servo"
+        timeout: 0.5
+        priority: 20 # Higher than nav, so it can override for fine-tuning
+
+    # Define locks
+    # If a message is received on the 'joy' topic, it will lock out all
+    # topics with a priority less than 100 for 1 second.
+    locks:
+      -
+        topic: "/cmd_vel/joy"
+        timeout: 1.0
+        priority: 100

--- a/indoor_drone_nav_v2/launch/control.launch.py
+++ b/indoor_drone_nav_v2/launch/control.launch.py
@@ -1,0 +1,23 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    """
+    Launch file for starting the control system, including the twist_mux.
+    """
+    pkg_share = get_package_share_directory('indoor_drone_nav_v2')
+
+    twist_mux_params = os.path.join(pkg_share, 'config', 'control', 'twist_mux.yaml')
+
+    return LaunchDescription([
+        Node(
+            package='twist_mux',
+            executable='twist_mux',
+            name='twist_mux',
+            output='screen',
+            parameters=[twist_mux_params],
+            remappings=[('/cmd_vel_out', '/cmd_vel_out')] # Explicitly remap the output
+        )
+    ])

--- a/indoor_drone_nav_v2/launch/nav2.launch.py
+++ b/indoor_drone_nav_v2/launch/nav2.launch.py
@@ -17,6 +17,9 @@ def generate_launch_description():
     # Get the path to the custom Nav2 parameters file
     nav2_params_file = os.path.join(pkg_share, 'config', 'nav2', 'nav2.yaml')
 
+    # Define the remapping
+    remappings = [('/cmd_vel', '/cmd_vel/nav')]
+
     return LaunchDescription([
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
@@ -29,5 +32,6 @@ def generate_launch_description():
                 'autostart': 'true',
                 'use_composition': 'true'
             }.items(),
+            remappings=remappings
         )
     ])

--- a/indoor_drone_nav_v2/launch/px4_basic.launch.py
+++ b/indoor_drone_nav_v2/launch/px4_basic.launch.py
@@ -29,6 +29,13 @@ def generate_launch_description():
         output='screen'
     )
 
+    velocity_bridge_node = Node(
+        package='indoor_drone_nav_v2',
+        executable='velocity_bridge_node',
+        name='velocity_bridge_node',
+        output='screen'
+    )
+
     # Mission Execution
     mission_executor_node = Node(
         package='indoor_drone_nav_v2',
@@ -67,6 +74,17 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(nav2_launch_file)
     )
 
+    # Control System
+    control_launch_file = os.path.join(
+        get_package_share_directory('indoor_drone_nav_v2'),
+        'launch',
+        'control.launch.py'
+    )
+
+    control_node = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(control_launch_file)
+    )
+
     # Extended Kalman Filter for Sensor Fusion
     ekf_config_file = os.path.join(get_package_share_directory('indoor_drone_nav_v2'), 'config', 'ekf', 'ekf.yaml')
     ekf_node = Node(
@@ -81,10 +99,12 @@ def generate_launch_description():
     return LaunchDescription([
         state_aggregator_node,
         action_server_node,
+        velocity_bridge_node,
         mission_executor_node,
         gui_server_node,
         rtabmap_node,
         nav2_node,
+        control_node,
         ekf_node,
         # In a complete system, other nodes for SLAM, safety, etc., would be added here.
     ])

--- a/indoor_drone_nav_v2/package.xml
+++ b/indoor_drone_nav_v2/package.xml
@@ -20,6 +20,7 @@
   <depend>slam_toolbox</depend>
   <depend>rtabmap_ros</depend>
   <depend>nav2_bringup</depend>
+  <depend>twist_mux</depend>
   <depend>cartographer_ros</depend>
   <depend>robot_localization</depend>
 

--- a/indoor_drone_nav_v2/setup.py
+++ b/indoor_drone_nav_v2/setup.py
@@ -49,6 +49,7 @@ setup(
             'path_planner_node = indoor_drone_nav_v2.mission_planning.path_planner_node:main',
             'object_detection_node = indoor_drone_nav_v2.ml_modules.object_detection_node:main',
             'visual_servoing_node = indoor_drone_nav_v2.ml_modules.visual_servoing_node:main',
+            'velocity_bridge_node = indoor_drone_nav_v2.drone_interfaces.velocity_bridge_node:main',
         ],
     },
 )

--- a/indoor_drone_nav_v2/src/indoor_drone_nav_v2/drone_interfaces/velocity_bridge_node.py
+++ b/indoor_drone_nav_v2/src/indoor_drone_nav_v2/drone_interfaces/velocity_bridge_node.py
@@ -1,0 +1,45 @@
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import Twist
+
+class VelocityBridgeNode(Node):
+    """
+    A simple node that subscribes to the output of the twist_mux and
+    publishes it to the MAVROS setpoint_velocity topic.
+    """
+    def __init__(self):
+        super().__init__('velocity_bridge_node')
+        self.get_logger().info("Velocity Bridge Node starting...")
+
+        # Publisher to MAVROS
+        self.mavros_publisher = self.create_publisher(
+            Twist,
+            '/mavros/setpoint_velocity/cmd_vel_unstamped',
+            10
+        )
+
+        # Subscriber to twist_mux output
+        self.twist_mux_subscriber = self.create_subscription(
+            Twist,
+            '/cmd_vel_out',
+            self.twist_mux_callback,
+            10
+        )
+
+        self.get_logger().info("Velocity Bridge Node started.")
+
+    def twist_mux_callback(self, msg: Twist):
+        """Callback for the twist_mux subscriber."""
+        # Simply republish the message to the MAVROS topic
+        self.mavros_publisher.publish(msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = VelocityBridgeNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/indoor_drone_nav_v2/src/indoor_drone_nav_v2/ml_modules/visual_servoing_node.py
+++ b/indoor_drone_nav_v2/src/indoor_drone_nav_v2/ml_modules/visual_servoing_node.py
@@ -12,7 +12,7 @@ class VisualServoingNode(Node):
         self.get_logger().info("Visual Servoing Node starting...")
 
         # Publisher for velocity commands
-        self.cmd_vel_publisher = self.create_publisher(Twist, '/cmd_vel', 10)
+        self.cmd_vel_publisher = self.create_publisher(Twist, '/cmd_vel/servo', 10)
 
         # Subscriber for the bounding box
         self.bbox_subscriber = self.create_subscription(

--- a/indoor_drone_nav_v2/testing_framework/integration_tests/test_twist_mux_integration.py
+++ b/indoor_drone_nav_v2/testing_framework/integration_tests/test_twist_mux_integration.py
@@ -1,0 +1,86 @@
+import os
+import unittest
+import pytest
+import rclpy
+from rclpy.node import Node
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+from ament_index_python.packages import get_package_share_directory
+
+import time
+import threading
+from geometry_msgs.msg import Twist
+
+PKG_NAME = 'indoor_drone_nav_v2'
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Generates the launch description for the twist_mux integration test."""
+    pkg_share = get_package_share_directory(PKG_NAME)
+    control_launch_file = os.path.join(pkg_share, 'launch', 'control.launch.py')
+
+    return LaunchDescription([
+        IncludeLaunchDescription(PythonLaunchDescriptionSource(control_launch_file)),
+        ReadyToTest(),
+    ])
+
+class TwistMuxIntegrationTest(unittest.TestCase):
+
+    def setUp(self):
+        """Set up the test node and subscribers/publishers."""
+        rclpy.init()
+        self.node = rclpy.create_node('twist_mux_integration_tester')
+
+        # Publishers for the input topics
+        self.nav_pub = self.node.create_publisher(Twist, '/cmd_vel/nav', 10)
+        self.servo_pub = self.node.create_publisher(Twist, '/cmd_vel/servo', 10)
+
+        # Subscriber to the output topic
+        self.out_sub = self.node.create_subscription(
+            Twist, '/cmd_vel_out', self.cmd_vel_out_callback, 10)
+        self.received_twists = []
+
+        self.executor = rclpy.executors.SingleThreadedExecutor()
+        self.executor.add_node(self.node)
+        self.executor_thread = threading.Thread(target=self.executor.spin)
+        self.executor_thread.start()
+
+    def tearDown(self):
+        """Clean up resources."""
+        self.node.destroy_node()
+        rclpy.shutdown()
+        self.executor_thread.join()
+
+    def cmd_vel_out_callback(self, msg):
+        """Callback for the /cmd_vel_out topic."""
+        self.received_twists.append(msg)
+
+    def test_priority(self):
+        """
+        Test that the higher-priority topic is chosen.
+        1. Publish to the low-priority topic (/cmd_vel/nav).
+        2. Check that the output matches.
+        3. Publish to the high-priority topic (/cmd_vel/servo).
+        4. Check that the output now matches the high-priority command.
+        """
+        time.sleep(1) # Give the system time to start up
+
+        # Publish to low-priority topic
+        nav_msg = Twist()
+        nav_msg.linear.x = 1.0
+        self.nav_pub.publish(nav_msg)
+        time.sleep(0.5)
+
+        self.assertGreater(len(self.received_twists), 0)
+        self.assertAlmostEqual(self.received_twists[-1].linear.x, 1.0)
+
+        # Publish to high-priority topic
+        servo_msg = Twist()
+        servo_msg.linear.x = 2.0
+        self.servo_pub.publish(servo_msg)
+        time.sleep(0.5)
+
+        self.assertGreater(len(self.received_twists), 1)
+        self.assertAlmostEqual(self.received_twists[-1].linear.x, 2.0)


### PR DESCRIPTION
This commit resolves a critical architectural issue where multiple nodes (Nav2, visual servoing) could attempt to publish velocity commands simultaneously, leading to unpredictable behavior.

It introduces the `twist_mux` package to arbitrate between these control inputs in a safe and prioritized manner.

Key changes:
- Integrated `twist_mux` with a new configuration file defining priorities for different control sources (joystick, Nav2, visual servoing).
- Refactored the Nav2 launch and visual servoing node to publish to dedicated `twist_mux` input topics.
- Added a new `VelocityBridgeNode` to subscribe to the arbitrated output of `twist_mux` and forward the final command to MAVROS.
- Added a new integration test to verify that `twist_mux` correctly selects the command from the highest-priority source.